### PR TITLE
LENS-1517: Fix urlparse import in auth.py

### DIFF
--- a/contrib/clients/python/lens/client/auth.py
+++ b/contrib/clients/python/lens/client/auth.py
@@ -18,7 +18,10 @@ import kerberos
 from requests.auth import AuthBase
 import subprocess
 import threading
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 
 class SpnegoAuth(AuthBase):


### PR DESCRIPTION
Simple change to handle both python2 and python3 use-cases. Have tested fix with python 3.5.2 and 2.7.12.