### PR TITLE
[LENS-1543] fix replaceAll() to replace() to improve performance

### DIFF
--- a/lens-cube/src/main/java/org/apache/lens/cube/metadata/DateUtil.java
+++ b/lens-cube/src/main/java/org/apache/lens/cube/metadata/DateUtil.java
@@ -182,8 +182,8 @@ public final class DateUtil {
     Matcher relativeMatcher = P_RELATIVE.matcher(str);
     if (relativeMatcher.find()) {
       String nowWithGranularity = relativeMatcher.group();
-      nowWithGranularity = nowWithGranularity.replaceAll("now", "");
-      nowWithGranularity = nowWithGranularity.replaceAll("\\.", "");
+      nowWithGranularity = nowWithGranularity.replace("now", "");
+      nowWithGranularity = nowWithGranularity.replace(".", "");
 
       Matcher granularityMatcher = P_UNIT.matcher(nowWithGranularity);
       if (granularityMatcher.find()) {


### PR DESCRIPTION
Fix Issue [#LENS-1543](https://issues.apache.org/jira/browse/LENS-1543)
The replaceAll() method will compile the given regular expression ahead of time even though the given string is simply a plain string, which will have a bad performance. At this time, the replace() method is recommended to gain a good performance.