### PR TITLE
Prepared Query should come from DB after 10 minutes.

### DIFF
--- a/lens-driver-jdbc/src/main/java/org/apache/lens/driver/jdbc/JDBCDriver.java
+++ b/lens-driver-jdbc/src/main/java/org/apache/lens/driver/jdbc/JDBCDriver.java
@@ -556,6 +556,8 @@ public class JDBCDriver extends AbstractLensDriver {
   public QueryCost estimate(AbstractQueryContext qctx) throws LensException {
     MethodMetricsContext validateGauge = MethodMetricsFactory.createMethodGauge(qctx.getDriverConf(this), true,
       VALIDATE_GAUGE);
+    String rewrittenQuery = rewriteQuery(qctx);
+    qctx.setSelectedDriverQuery(rewrittenQuery);
     validate(qctx);
     validateGauge.markSuccess();
     return calculateQueryCost(qctx);

--- a/lens-server-api/src/main/java/org/apache/lens/server/api/query/PreparedQueryContext.java
+++ b/lens-server-api/src/main/java/org/apache/lens/server/api/query/PreparedQueryContext.java
@@ -77,7 +77,7 @@ public class PreparedQueryContext extends AbstractQueryContext implements Delaye
   /**
    * The millis in week.
    */
-  private static long millisInWeek = 7 * 24 * 60 * 60 * 1000;
+  private static long millisInTenMinutes = 10 * 60 * 1000;
 
   /**
    * Instantiates a new prepared query context.
@@ -129,7 +129,7 @@ public class PreparedQueryContext extends AbstractQueryContext implements Delaye
     if (this.prepareStartTime != null) {
       Date now = new Date();
       long elapsedMills = now.getTime() - this.prepareStartTime.getTime();
-      delayMillis = millisInWeek - elapsedMills;
+      delayMillis = millisInTenMinutes - elapsedMills;
       return units.convert(delayMillis, TimeUnit.MILLISECONDS);
     } else {
       return Integer.MAX_VALUE;

--- a/lens-server/src/main/java/org/apache/lens/server/query/LensServerDAO.java
+++ b/lens-server/src/main/java/org/apache/lens/server/query/LensServerDAO.java
@@ -35,11 +35,11 @@ import org.apache.lens.api.query.QueryHandle;
 import org.apache.lens.api.query.QueryStatus;
 import org.apache.lens.server.api.error.LensException;
 import org.apache.lens.server.api.query.FinishedLensQuery;
+import org.apache.lens.server.api.query.PreparedLensQuery;
 import org.apache.lens.server.api.query.PreparedQueryContext;
 import org.apache.lens.server.api.query.QueryContext;
 import org.apache.lens.server.session.LensSessionImpl;
 import org.apache.lens.server.util.UtilityMethods;
-
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.dbutils.*;
 import org.apache.commons.dbutils.handlers.BeanHandler;
@@ -867,5 +867,19 @@ public class LensServerDAO {
   } finally {
       DbUtils.closeQuietly(conn);
     }
+  }
+
+  public PreparedLensQuery getPreparedQuery(String handle) {
+    ResultSetHandler<PreparedLensQuery> rsh = new BeanHandler<>(PreparedLensQuery.class,
+        new BasicRowProcessor(new FinishedLensQueryBeanProcessor()));
+    String sql = "select * from prepared_queries where handle=?";
+    QueryRunner runner = new QueryRunner(ds);
+    try {
+      PreparedLensQuery preparedLensQuery = runner.query(sql, rsh, handle);
+      return preparedLensQuery;
+    } catch (SQLException e) {
+      log.error("SQL exception while executing query.", e);
+    }
+    return null;
   }
 }

--- a/lens-server/src/main/java/org/apache/lens/server/query/QueryExecutionServiceImpl.java
+++ b/lens-server/src/main/java/org/apache/lens/server/query/QueryExecutionServiceImpl.java
@@ -2461,7 +2461,13 @@ public class QueryExecutionServiceImpl extends BaseLensService implements QueryE
       acquire(sessionHandle);
       PreparedQueryContext ctx = preparedQueries.get(prepareHandle);
       if (ctx == null) {
-        throw new NotFoundException("Prepared query not found " + prepareHandle);
+        PreparedLensQuery preparedLensQuery = lensServerDao.getPreparedQuery(prepareHandle.getQueryHandleString());
+        if (preparedLensQuery == null) {
+          throw new NotFoundException("Prepared query not found " + prepareHandle);
+        }
+        ctx = new PreparedQueryContext(preparedLensQuery.getUserquery(), preparedLensQuery.getSubmitter(), conf,
+            drivers.values());
+        ctx.setSelectedDriverQuery(preparedLensQuery.getDriverquery());
       }
       return ctx;
     } finally {

--- a/lens-server/src/test/java/org/apache/lens/server/query/TestLensDAO.java
+++ b/lens-server/src/test/java/org/apache/lens/server/query/TestLensDAO.java
@@ -260,7 +260,10 @@ public class TestLensDAO extends LensJerseyTest {
       PreparedQueryContext preparedQueryContext = new PreparedQueryContext("query", "user1", driverConf,
           createDriver(driverConf));
       preparedQueryContext.setPrepareEndTime(new Date());
-      service.lensServerDao.insertPreparedQuery(preparedQueryContext);
+      service.lensServerDao.insertPreparedQuery(preparedQueryContext);  
+      PreparedLensQuery preparedLensQuery = service.lensServerDao.getPreparedQuery(preparedQueryContext.getQueryHandleString());
+      Assert.assertEquals(preparedLensQuery.getHandle(), preparedQueryContext.getQueryHandleString());
+      Assert.assertEquals(preparedLensQuery.getSubmitter(), "user1");
     } catch (Exception e) {
       Assert.fail("it shouldn't be coming in this catch block");
     }


### PR DESCRIPTION
1) JDBCDriver.java: Changes in JDBCDriver.java was supposed to happen in https://github.com/apache/lens/pull/34, I had even mentioned in the comment section of that PR(see item 2). Some how I forgot to checkin this line.
2) PreparedQueryContext.java: This is due to the fact, we were storing PreparedQueries for one week, it was bloating the memory, I decreased this to 10 minutes, beyond 10 minutes, it will come from DB.
3) LensServerDAO.java -- Beyond 10 minutes, I am pulling from DB.
4) QueryExecutionServiceImpl.java  -- If prepraedQuery is not present in memory then I am pulling from the DB.
5) TestLensDAO.java -- Unit test case for pulling the data from DB.